### PR TITLE
Fix for the default branch name

### DIFF
--- a/.github/workflows/validate-parent.yml
+++ b/.github/workflows/validate-parent.yml
@@ -1,8 +1,6 @@
 name: Validate parent of fork
 
 on:
-  push: 
-    branches: ref-name-fix
   issues:
     types: [opened]
 
@@ -38,8 +36,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const issue_id = 224
-            const issue_title = `Parent repository for [asml-actions/python-coverage-comment-action] has updates available`
+            const issue_id = ${{ github.event.issue.number }}
+            const issue_title = `${{ github.event.issue.title }}`
             const repo_name = issue_title.substring(issue_title.indexOf("/") + 1,  issue_title.lastIndexOf("]"));
             let repoData =await github.rest.repos.get({
               owner: context.repo.owner,
@@ -69,6 +67,6 @@ jobs:
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: 224,
+              issue_number: context.issue.number,
               labels: [`${label}`]
             })

--- a/.github/workflows/validate-parent.yml
+++ b/.github/workflows/validate-parent.yml
@@ -1,6 +1,8 @@
 name: Validate parent of fork
 
 on:
+  push: 
+    branches: ref-name-fix
   issues:
     types: [opened]
 
@@ -36,8 +38,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const issue_id = ${{ github.event.issue.number }}
-            const issue_title = `${{ github.event.issue.title }}`
+            const issue_id = 179
+            const issue_title = `Parent repository for [asml-actions/super-linter] has updates available`
             const repo_name = issue_title.substring(issue_title.indexOf("/") + 1,  issue_title.lastIndexOf("]"));
             let repoData =await github.rest.repos.get({
               owner: context.repo.owner,
@@ -67,6 +69,6 @@ jobs:
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: 179,
               labels: [`${label}`]
             })

--- a/.github/workflows/validate-parent.yml
+++ b/.github/workflows/validate-parent.yml
@@ -1,10 +1,10 @@
 name: Validate parent of fork
 
 on:
+  push: 
+    branches: ref-name-fix
   issues:
-    types: 
-      - opened
-      - labeled  
+    types: [opened]
 
 permissions:
   issues: write
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate-parent:
-    if: github.event.label.name == 'scan-parent' || github.issue.event =='opened'
+    if:  ${{ vars.VALIDATE_PARENT == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -38,8 +38,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const issue_id = ${{ github.event.issue.number }}
-            const issue_title = `${{ github.event.issue.title }}`
+            const issue_id = 225
+            const issue_title = `Parent repository for [asml-actions/stale-branches] has updates available `
             const repo_name = issue_title.substring(issue_title.indexOf("/") + 1,  issue_title.lastIndexOf("]"));
             let repoData =await github.rest.repos.get({
               owner: context.repo.owner,
@@ -69,6 +69,6 @@ jobs:
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: 225,
               labels: [`${label}`]
             })

--- a/.github/workflows/validate-parent.yml
+++ b/.github/workflows/validate-parent.yml
@@ -1,10 +1,10 @@
 name: Validate parent of fork
 
 on:
-  push: 
-    branches: ref-name-fix
   issues:
-    types: [opened]
+    types: 
+      - opened
+      - labeled  
 
 permissions:
   issues: write
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate-parent:
-    if:  ${{ vars.VALIDATE_PARENT == 'true' }}
+    if: ${{github.event.label.name == 'scan-parent' || github.issue.event =='opened'}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -38,8 +38,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const issue_id = 225
-            const issue_title = `Parent repository for [asml-actions/stale-branches] has updates available `
+            const issue_id = ${{ github.event.issue.number }}
+            const issue_title = `${{ github.event.issue.title }}`
             const repo_name = issue_title.substring(issue_title.indexOf("/") + 1,  issue_title.lastIndexOf("]"));
             let repoData =await github.rest.repos.get({
               owner: context.repo.owner,
@@ -69,6 +69,6 @@ jobs:
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: 225,
+              issue_number: context.issue.number,
               labels: [`${label}`]
             })

--- a/.github/workflows/validate-parent.yml
+++ b/.github/workflows/validate-parent.yml
@@ -38,8 +38,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const issue_id = 179
-            const issue_title = `Parent repository for [asml-actions/super-linter] has updates available`
+            const issue_id = 224
+            const issue_title = `Parent repository for [asml-actions/python-coverage-comment-action] has updates available`
             const repo_name = issue_title.substring(issue_title.indexOf("/") + 1,  issue_title.lastIndexOf("]"));
             let repoData =await github.rest.repos.get({
               owner: context.repo.owner,
@@ -69,6 +69,6 @@ jobs:
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: 179,
+              issue_number: 224,
               labels: [`${label}`]
             })

--- a/.github/workflows/validate-parent.yml
+++ b/.github/workflows/validate-parent.yml
@@ -2,7 +2,9 @@ name: Validate parent of fork
 
 on:
   issues:
-    types: [opened]
+    types: 
+      - opened
+      - labeled  
 
 permissions:
   issues: write
@@ -10,7 +12,7 @@ permissions:
 
 jobs:
   validate-parent:
-    if:  ${{ vars.VALIDATE_PARENT == 'true' }}
+    if: github.event.label.name == 'scan-parent' || github.issue.event =='opened'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo

--- a/code-scan.js
+++ b/code-scan.js
@@ -167,7 +167,8 @@ async function run() {
   const forkRepo = await octokitRequest("createFork");
 
   await wait(5000);
-  console.log(`ref name for default branch ${forkRepo.default_branch}`)
+  console.log(`fork repo object`)
+  console.log(forkRepo)
   await putRequest("vulnerability-alerts", {}); // Enable dependabot
 
   await wait(5000);

--- a/code-scan.js
+++ b/code-scan.js
@@ -2,6 +2,7 @@ const { Octokit } = require("@octokit/rest");
 const core = require("@actions/core");
 const { countReset } = require("console");
 const fs = require("fs");
+const { fork } = require("child_process");
 const token = process.argv[2];
 const repo = process.argv[3];
 const originalOwner = process.argv[4];
@@ -166,6 +167,7 @@ async function run() {
   const forkRepo = await octokitRequest("createFork");
 
   await wait(5000);
+  console.log(`ref name for default branch ${forkRepo.default_branch}`)
   await putRequest("vulnerability-alerts", {}); // Enable dependabot
 
   await wait(5000);

--- a/code-scan.js
+++ b/code-scan.js
@@ -182,7 +182,7 @@ async function run() {
   await wait(15000);
   const codeqlStatus = await triggerCodeqlScan(
     `codeql-analysis-check.yml`,
-    forkRepo.default_branch
+    forkRepo.parent.default_branch
   );
   if (codeqlStatus == 204) {
     //Wait for the scan to complete

--- a/code-scan.js
+++ b/code-scan.js
@@ -26,17 +26,10 @@ async function wait(milliseconds) {
   });
 }
 
-async function octokitRequest(request, extraArgs = '') {
+async function octokitRequest(request, extraArgs = {}) {
   console.log(`Running ${request} function`);
   try {
-    // few functions require different properties
-    let requestProperties = { owner, repo };
-    if (extraArgs) {
-      for (let key in extraArgs) {
-        requestProperties[key] = extraArgs[key];
-      }
-    }
-    console.log(`requestProperties: ${JSON.stringify(requestProperties)}`)
+    const requestProperties = { owner, repo ,...extraArgs};
     const response = await octokitFunctions[request](requestProperties);
     console.log(`Function ${request} finished succesfully`);
     return response.data;

--- a/code-scan.js
+++ b/code-scan.js
@@ -26,7 +26,7 @@ async function wait(milliseconds) {
   });
 }
 
-async function octokitRequest(request, extraArgs = None) {
+async function octokitRequest(request, extraArgs = '') {
   console.log(`Running ${request} function`);
   try {
     // few functions require different properties

--- a/code-scan.js
+++ b/code-scan.js
@@ -29,7 +29,7 @@ async function wait(milliseconds) {
 async function octokitRequest(request, extraArgs = {}) {
   console.log(`Running ${request} function`);
   try {
-    const requestProperties = { owner, repo ,...extraArgs};
+    const requestProperties = { owner, repo, ...extraArgs };
     const response = await octokitFunctions[request](requestProperties);
     console.log(`Function ${request} finished succesfully`);
     return response.data;
@@ -72,17 +72,6 @@ async function pushWorkflowFile() {
   } catch (error) {
     console.error("Error creating workflow file:", error);
   }
-}
-
-async function triggerCodeqlScan(workflow_id, ref) {
-  console.log(`Trigger codeql scan`);
-  const response = await octokit.rest.actions.createWorkflowDispatch({
-    owner,
-    repo,
-    workflow_id,
-    ref,
-  });
-  return response.status;
 }
 
 async function waitForCodeqlScan() {
@@ -151,10 +140,10 @@ async function run() {
 
   //Trigger a scan
   await wait(15000);
-  const codeqlStatus = await triggerCodeqlScan(
-    `codeql-analysis-check.yml`,
-    forkRepo.parent.default_branch
-  );
+  const codeqlStatus = await octokitRequest("triggerCodeqlScan", {
+    workflow_id: `codeql-analysis-check.yml`,
+    ref: forkRepo.parent.default_branch,
+  });
   if (codeqlStatus == 204) {
     //Wait for the scan to complete
     console.log(`Wait for job to start !`);

--- a/code-scan.js
+++ b/code-scan.js
@@ -167,8 +167,6 @@ async function run() {
   const forkRepo = await octokitRequest("createFork");
 
   await wait(5000);
-  console.log(`fork repo object`)
-  console.log(forkRepo)
   await putRequest("vulnerability-alerts", {}); // Enable dependabot
 
   await wait(5000);


### PR DESCRIPTION
Looks like Github API has a bug where it returns wrong branch name for newly created fork, hence it's now fetched from its parent. 
Also added run on scan labeling for rescanning or using on existing issues. JS file also got a small refactor