### PR TITLE
Force update the tags to sync with parent

### DIFF
--- a/update-fork.ps1
+++ b/update-fork.ps1
@@ -68,9 +68,6 @@ function UpdateFork {
     Write-Host "Merging changes from parent repo"
     git merge github/$($parent.parentDefaultBranch) --ff
 
-    $HEAD = git rev-parse HEAD
-    Write-Host "HEAD after merge [$HEAD]"
-    
     # check if there are any merge conflicts
     $mergeConflict = git status | Select-String "both modified"
     if ($mergeConflict) {

--- a/update-fork.ps1
+++ b/update-fork.ps1
@@ -60,8 +60,6 @@ function UpdateFork {
     Write-Host "Pull changes from parent repo"
     git pull github $parent.parentDefaultBranch
 
-    Write-Host "Current HEAD"
-    git rev-parse HEAD
     # make sure you are on the right branch
     Write-Host "Pulling all changes from the parent on branch [$($parent.parentDefaultBranch)]"
     git checkout $parent.parentDefaultBranch
@@ -70,8 +68,8 @@ function UpdateFork {
     Write-Host "Merging changes from parent repo"
     git merge github/$($parent.parentDefaultBranch) --ff
 
-    Write-Host "HEAD after merge"
-    git rev-parse HEAD
+    $HEAD = git rev-parse HEAD
+    Write-Host "HEAD after merge [$HEAD]"
     
     # check if there are any merge conflicts
     $mergeConflict = git status | Select-String "both modified"
@@ -83,10 +81,10 @@ function UpdateFork {
 
     # push the changes back to your repo
     Write-Host "Pushing tags back to fork"
-    git push origin --tags
+    git push --force origin --tags
     
     Write-Host "Pushing changes back to fork"
-    git push origin $parent.parentDefaultBranch --tags
+    git push --force origin $parent.parentDefaultBranch --tags
     
 
     Write-Host "Completed fork update"


### PR DESCRIPTION
When existing tags are modified push tag command returns 'Everything up to date' and skips the update